### PR TITLE
fix(db): correct category insert fields in createCategory controller

### DIFF
--- a/src/controllers/categories/categoriesController.js
+++ b/src/controllers/categories/categoriesController.js
@@ -33,8 +33,8 @@ export async function createCategory(req, res) {
     }
 
     const result = await query(
-      "INSERT INTO categories (name, icon, user_id) VALUES ($1, $2, $3) RETURNING *",
-      [name, description || null, req.user.id]
+      "INSERT INTO categories (name, description, user_id) VALUES ($1, $2, $3) RETURNING *",
+      [name, description, req.user.id]
     );
     res.status(201).json(result.rows[0]);
   } catch (err) {


### PR DESCRIPTION
###  Bug Fix

This PR fixes a database insertion error in the `createCategory` controller:

---

###  Problem
The original SQL insert statement attempted to insert into a non-existent `icon` column:

```sql
INSERT INTO categories (name, icon, user_id)